### PR TITLE
Initial commit of support for AddressObjectType in Observable

### DIFF
--- a/object/addressObjectType.go
+++ b/object/addressObjectType.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Bret Jordan, All rights reserved.
+//
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package object
+
+// ----------------------------------------------------------------------
+// Defines Type
+// ----------------------------------------------------------------------
+
+type AddressObjectType struct {
+	Condition string `json:"condition,omitempty"`
+	Value     string `json:"address_value,omitempty"`
+}
+
+// ----------------------------------------------------------------------
+// Create Functions
+// ----------------------------------------------------------------------
+
+func NewAddressObject() AddressObjectType {
+	obj := CreateAddressObject()
+	return obj
+}
+
+func CreateAddressObject() AddressObjectType {
+	var obj AddressObjectType
+	return obj
+}
+
+// ----------------------------------------------------------------------
+// Methods
+// ----------------------------------------------------------------------
+
+func (this *AddressObjectType) SetConditionEquals() {
+	this.Condition = "Equals"
+}
+
+func (this *AddressObjectType) AddValue(v string) {
+	this.Value = v
+}

--- a/object/propertiesType.go
+++ b/object/propertiesType.go
@@ -16,10 +16,12 @@ import (
 // ----------------------------------------------------------------------
 
 type PropertiesType struct {
-	Id         string          `json:"id,omitempty"`
-	IdRef      string          `json:"idref,omitempty"`
-	Type       string          `json:"type,omitempty"`
-	UriObjects []UriObjectType `json:"uri_objects,omitempty"`
+	Id             string              `json:"id,omitempty"`
+	IdRef          string              `json:"idref,omitempty"`
+	Type           string              `json:"type,omitempty"`
+	Category       string              `json:"category,omitempty"`
+	UriObjects     []UriObjectType     `json:"uri_objects,omitempty"`
+	AddressObjects []AddressObjectType `json:"address_objects,omitempty"`
 }
 
 // ----------------------------------------------------------------------
@@ -49,11 +51,22 @@ func (this *PropertiesType) AddType(t string) {
 	this.Type = t
 }
 
+func (this *PropertiesType) AddCategory(c string) {
+	this.Category = c
+}
+
 func (this *PropertiesType) AddEqualsUriValue(uri string) {
 	uriobj := NewUriObject()
 	uriobj.SetConditionEquals()
 	uriobj.AddValue(uri)
 	this.AddUriObject(uriobj)
+}
+
+func (this *PropertiesType) AddEqualsAddressValue(addr string) {
+	addrobj := NewAddressObject()
+	addrobj.SetConditionEquals()
+	addrobj.AddValue(addr)
+	this.AddAddressObject(addrobj)
 }
 
 func (this *PropertiesType) AddUriObject(obj UriObjectType) {
@@ -62,4 +75,14 @@ func (this *PropertiesType) AddUriObject(obj UriObjectType) {
 		this.UriObjects = a
 	}
 	this.UriObjects = append(this.UriObjects, obj)
+}
+
+func (this *PropertiesType) AddAddressObject(obj AddressObjectType) {
+	// Don't really need this... append will make the slice for you if it
+	// doesn't already exist.
+	if this.AddressObjects == nil {
+		a := make([]AddressObjectType, 0)
+		this.AddressObjects = a
+	}
+	this.AddressObjects = append(this.AddressObjects, obj)
 }


### PR DESCRIPTION
I'm curious if this is the right approach?

I'm trying to formulate something similar to the indicator portion of the example [here](http://stixproject.github.io/documentation/idioms/c2-indicator/).

Using the `indicator-mini.go` example from the `libstix` repo as a starting point, I was able to generate the following with this addition:

```
package main

import (
	"encoding/json"
	"fmt"

	"github.com/freestix/libstix/indicator"
	"github.com/freestix/libstix/stix"
)

func main() {
	s := stix.New()
	s.SetTimestampToNow()

	i := s.NewIndicator()
	i.SetTimestampToNow()
	i.AddType("IP Watchlist")

	o := i.NewObservable()
	p := o.GetObjectProperties()

	p.AddCategory("ipv4-addr")
	p.AddEqualsAddressValue("123.123.123.123")

	si := indicator.CreateSighting()
	si.CreateTimeStamp()

	sis := indicator.CreateSightings()
	sis.AddSighting(si)

	i.AddSightings(sis)

	out, _ := json.MarshalIndent(s, "", "  ")
	fmt.Println(string(out))
}

// output...

{
  "stix_package": {
    "id": "example:package-2cdf9433-6fc0-4796-bf8d-4edaf2140a2f",
    "timestamp": "2016-08-31T11:55:17-06:00",
    "indicators": [
      {
        "id": "example:indicator-9b291be4-cd72-463e-a72f-03b0a40fea69",
        "timestamp": "2016-08-31T11:55:17-06:00",
        "type": [
          "IP Watchlist"
        ],
        "observable": {
          "id": "example:observable-cee863ef-75ff-4b90-80c8-8aac565eab51",
          "object": {
            "id": "example:cyboxObject-2db93d28-e8ce-4c84-8424-411686c3905f",
            "properties": {
              "id": "example:object-0134a1ad-a2e0-4840-b142-518c48202e9a",
              "category": "ipv4-addr",
              "address_objects": [
                {
                  "condition": "Equals",
                  "address_value": "123.123.123.123"
                }
              ]
            }
          }
        },
        "sightings": {
          "sighting": [
            {
              "timestamp": "2016-08-31T11:55:17-06:00"
            }
          ]
        }
      }
    ]
  }
}
```